### PR TITLE
Executive Summary - Summary Tables 3&4

### DIFF
--- a/Exec_Summary_Child.Rmd
+++ b/Exec_Summary_Child.Rmd
@@ -81,13 +81,13 @@ load(paste0(Rdata_dir, "/", stns_param_summary_file))
 stns_param_summary_tbl <- dplyr::select(stns_param_summary, -c(DECIMAL_LAT, DECIMAL_LONG))
 
 colnames(stns_param_summary_tbl) <- c("Station ID", "Station Description",
-                                  "_E. coli_  Status", "_E. coli_ Trend", 
-                                  "_Enterococcus_ Status", "_Enterococcus_ Trend",
-                                  "DO Status", "DO Trend",
-                                  "pH Status", "pH Trend", 
-                                  "Temperature Status", "Temperature Trend",
-                                  "TP Status", "TP Trend", 
-                                  "TSS Status", "TSS Trend")
+                                      "DO Status", "DO Trend",
+                                      "_E. coli_  Status", "_E. coli_ Trend", 
+                                      "_Enterococcus_ Status", "_Enterococcus_ Trend",
+                                      "pH Status", "pH Trend", 
+                                      "Temperature Status", "Temperature Trend",
+                                      "TP Status","TP Trend", 
+                                      "TSS Status","TSS Trend")
 
 knitr::kable(stns_param_summary_tbl[,c(1:6,9:10)],
              padding = 2, digits = 3,


### PR DESCRIPTION
Summary tables 3&4 in the Executive Summary do not match the summary table in the Output Report. The order of colnames(stns_param_summary_tbl) needs to be changed to match the order of the colnames given in the Output Report. 